### PR TITLE
Update requirements.txt to resolve netmiko issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## In development
 
-- Added 'netmiko>=2.4.1' entry to requirements.txt.  See https://github.com/ktbyers/netmiko/issues/1304
+- Added 'netmiko>=2.4.1' entry to requirements.txt. See [PR #2](https://github.com/nre-learning/stackstorm-napalm/pull/2).
 
 ## 0.4.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## In development
+
+- Added 'netmiko>=2.4.1' entry to requirements.txt.  See https://github.com/ktbyers/netmiko/issues/1304
+
 ## 0.4.0
 
 - Driver reunification - switched to just "napalm" import, removed device-specific and napalm-base

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+# https://github.com/ktbyers/netmiko/issues/1304
+netmiko>=2.4.1
 napalm
 json2table
 GitPython


### PR DESCRIPTION
See netmiko issue [#1304](https://github.com/ktbyers/netmiko/issues/1304).  There was a breaking API change to textfsm, see PR [#37](https://github.com/google/textfsm/pull/37).  This broke netmiko, and netmiko resolved it in PR [#1292](https://github.com/ktbyers/netmiko/pull/1292).

Added "netmiko>=2.4.1" to requirements.txt.